### PR TITLE
Add additional variable for customisation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,3 +45,7 @@ yum_php_packages:
 php_owner: 'www-data'
 php_group: 'www-data'
 
+disabled_functions: exec,passthru,shell_exec,system,proc_open,popen
+disable_url_fopen: true
+main_socket: unix:/run/php-fpm/www.sock
+

--- a/tasks/php-fpm-centos.yml
+++ b/tasks/php-fpm-centos.yml
@@ -30,13 +30,13 @@
   lineinfile: "dest=/etc/php-fpm.d/www.conf state=present regexp='^;?listen.mode' line='listen.mode = 0660'"
   notify: restart php7-fpm on centos
 
-- name: Disable port upstream of php-fpm
-  lineinfile: "dest=/etc/nginx/conf.d/php-fpm.conf state=present regexp='^        server 127.0.0.1:9000' line='        #server 127.0.0.1:9000'"
-  notify: restart php7-fpm on centos
-
-- name: Enable socket upstream of php-fpm
-  lineinfile: "dest=/etc/nginx/conf.d/php-fpm.conf state=present regexp='^        #server unix:/run/php-fpm/www.sock;' line='        server unix:/run/php-fpm/www.sock;'"
-  notify: restart php7-fpm on centos
+- name: Adding nginx host file
+  template:
+    src=php-fpm.conf
+    dest=/etc/nginx/conf.d/php-fpm.conf
+    owner=root
+    group=root
+    mode=644
 
 - name: Set listen acl users
   lineinfile: "dest=/etc/php-fpm.d/www.conf state=present regexp='^;?listen.acl_users = nginx' line='listen.acl_users = nginx'"
@@ -75,6 +75,14 @@
               regexp='allow_url_fopen(\s)?='
               line='allow_url_fopen = Off'
   notify: restart php7-fpm on centos
+  when: disable_url_fopen|bool
+
+- name: Enable url fopen
+  lineinfile: dest=/etc/php.ini
+              regexp='allow_url_fopen(\s)?='
+              line='allow_url_fopen = On'
+  notify: restart php7-fpm on centos
+  when: disable_url_fopen|bool == false
 
 - name: Change soap.wsdl_cache_dir to new directory
   lineinfile: dest=/etc/php.ini
@@ -91,7 +99,7 @@
 - name: Exclude potentially harmfull php functions
   lineinfile: dest=/etc/php.ini
               regexp='disable_functions(\s)?='
-              line='disable_functions=exec,passthru,shell_exec,system,proc_open,popen'
+              line='disable_functions={{ disabled_functions }}'
   notify: restart php7-fpm on centos
 
 - name: Set post_max_size

--- a/tasks/php-fpm-ubuntu.yml
+++ b/tasks/php-fpm-ubuntu.yml
@@ -48,6 +48,7 @@
               regexp='allow_url_fopen(\s)?='
               line='allow_url_fopen = Off'
   notify: restart php7-fpm
+  when: disable_url_fopen|bool
 
 - name: Change soap.wsdl_cache_dir to new directory
   lineinfile: dest=/etc/php/7.0/fpm/php.ini

--- a/templates/php-fpm.conf
+++ b/templates/php-fpm.conf
@@ -1,0 +1,6 @@
+# PHP-FPM FastCGI server
+# network or unix domain socket configuration
+
+upstream php-fpm {
+        server {{ main_socket }};
+}


### PR DESCRIPTION
Change `php-fpm.conf` in CentOS to use template as when running multiple times caused the line to be added again which stopped Nginx from restarting.

1. add `disabled_functions` variable so this can be configured per project.
1. add `disable_url_fopen` as in some cases you may want this enabled.
1. add `main_socket` for `php-fpm.conf` template.
