### PR TITLE
Fixed deprecation errors thrown with Ansible 2.7

### DIFF
--- a/tasks/use-yum.yml
+++ b/tasks/use-yum.yml
@@ -16,16 +16,14 @@
 - name: Install requires package with yum
   become: true
   yum:
-    name: "{{ item }}"
-  with_items:
+    name:
     - libselinux-python
     - epel-release
 
 - name: Install the remi and ius repo from remote repo
   become: true
   yum:
-    name: "{{ item }}"
-  with_items:
+    name:
     - "http://rpms.remirepo.net/enterprise/remi-release-{{ ansible_distribution_major_version }}.rpm"
     - "https://centos{{ ansible_distribution_major_version }}.iuscommunity.org/ius-release.rpm"
 


### PR DESCRIPTION
Fixes the following deprecation warnings when running on yum systems:

> [DEPRECATION WARNING]: Invoking "yum" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: {{ item }}`, please use `name: {list}` and remove the loop. This feature will be removed in version
2.11. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.